### PR TITLE
Update JiraCarousel display hint

### DIFF
--- a/examples/JiraCarousel/JiraCarousel.ino
+++ b/examples/JiraCarousel/JiraCarousel.ino
@@ -112,6 +112,14 @@ void fetchIssues() {
 }
 
 void displayCurrentIssue() {
+    if (WiFi.status() != WL_CONNECTED || ssid.isEmpty()) {
+        tft.fillScreen(TFT_BLACK);
+        tft.setCursor(0, 0);
+        tft.setTextColor(TFT_WHITE, TFT_BLACK);
+        tft.println("Connect to Wi-Fi:");
+        tft.println("JiraCarouselSetup");
+        return;
+    }
     if (issues.empty()) {
         tft.fillScreen(TFT_BLACK);
         tft.setCursor(0, 0);
@@ -137,6 +145,12 @@ void setup() {
     Serial.begin(115200);
     tft.begin();
     tft.setRotation(1);
+
+    tft.fillScreen(TFT_BLACK);
+    tft.setCursor(0, 0);
+    tft.setTextColor(TFT_WHITE, TFT_BLACK);
+    tft.println("Connect to Wi-Fi:");
+    tft.println("JiraCarouselSetup");
 
     prefs.begin("jira", false);
     loadConfig();


### PR DESCRIPTION
## Summary
- show connection hint during setup
- keep hint on screen until Wi-Fi credentials connect

## Testing
- `pio run -e factory` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c8b8563e8832786428bcb38f7865e