### PR TITLE
Add vector include to JiraCarousel

### DIFF
--- a/examples/JiraCarousel/JiraCarousel.ino
+++ b/examples/JiraCarousel/JiraCarousel.ino
@@ -6,6 +6,7 @@
 #include <Preferences.h>
 #include <TFT_eSPI.h>
 #include <base64.h>
+#include <vector>
 #include "pin_config.h"
 
 // Web server for configuration


### PR DESCRIPTION
## Summary
- include `<vector>` in JiraCarousel example

## Testing
- `pio run -e factory` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c8b9c390c83278ab2768246137557